### PR TITLE
Enable for node 0.8 as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "blah"
   },
   "engines": {
-    "node": "~0.6.10"
+    "node": ">=0.6.10"
   },
   "dependencies": {
     "yamlparser": "0.0.2"


### PR DESCRIPTION
Due to the engine requirement in the package.json being ~0.6.10, it won't work with a major update to 0.8 -- although it works fine currently in node 0.8.1
