### PR TITLE
Add optional byte order mark to regex

### DIFF
--- a/examples/bom.md
+++ b/examples/bom.md
@@ -1,0 +1,3 @@
+﻿---
+title: Relax guy, I'm not hiding any BOMs
+---

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 
 const parser = require('yaml-js')
 const seperators = [ '---', '= yaml =']
+const optionalByteOrderMark = '\\ufeff?'
 const pattern = pattern = '^('
+      + optionalByteOrderMark
       + '((= yaml =)|(---))'
       + '$([\\s\\S]*?)'
       + '\\2'

--- a/tests/fm-test.js
+++ b/tests/fm-test.js
@@ -92,6 +92,19 @@ describe('fm(string)', function(){
       done()
     })
   })
+
+  it('works on files with byte order mark', function(done){
+    read('bom.md', function(err, data){
+      if (err) return done(err)
+
+      var content = fm(data)
+      
+      assert.ok(content.attributes)
+      assert.equal(content.attributes.title, "Relax guy, I'm not hiding any BOMs")
+      
+      done()
+    })
+  })
 })
 
 function read(file, callback){


### PR DESCRIPTION
Some unsavoury text editors (looking at you, Visual Studio) prepend a byte order mark (BOM) at the start of each UTF8 file. This causes the regex to fail.

The fix: add an optional check for UTF8 BOM to the regex.