### PR TITLE
Update index.js 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 
 const parser = require('yaml-js')
 const seperators = [ '---', '= yaml =']
-const pattern = pattern = '^('
+const pattern = '^('
       + '((= yaml =)|(---))'
       + '$([\\s\\S]*?)'
       + '\\2'


### PR DESCRIPTION
const + assignment causes error in firefox: SyntaxError: invalid assignment to const pattern