### PR TITLE
Add `attributes` to the returned object when no match is found

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function parse(string) {
 
   if (! match) {
     return {
+      attributes: {},
       body: string
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -160,6 +160,7 @@ test('Supports live updating', function(t) {
   var content = fm(string)
 
   t.same(content, {
+    attributes: {},
     body: string
   })
 


### PR DESCRIPTION
This standardizes the return object schema across all code branches. The previous implementation only returns `{ body: ... }`, which could cause reference errors if users expect the `attributes` field to be populated later on in a live-updating case.

This PR is a follow-up to issue #30.

Passes the test harness, caveated on changing test 37's expected result to match the schema change.