### PR TITLE
Add support for YAML document end marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This modules does not do any IO (file loading or reading), only extracting yaml front matter from strings.
 
-This concept that was originally introduced to me through the [jeykll][jeykll] blogging system and is pretty useful where you want to be able to easily add meta-data to content without the need for a database. YAML is extracted from the the top of a file between matching separators of "---" or "= yaml =".
+This concept that was originally introduced to me through the [jeykll][jeykll] blogging system and is pretty useful where you want to be able to easily add meta-data to content without the need for a database. YAML is extracted from the the top of a file between matching separators of "---" or "= yaml =". It will also extract YAML between a separator and "...".
 
 <!-- This is part of a long running project I have been working on where I am splitting out internals of [haiku][haiku] into to separate, more useful and shareable modules. If your in need of a static site generator [check it out][haiku]. -->
 

--- a/examples/dots-ending.md
+++ b/examples/dots-ending.md
@@ -1,0 +1,6 @@
+---
+title: Example with dots document ending
+description: Just an example of using `...`
+...
+
+It shouldn't break with ...

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var pattern = '^('
       + optionalByteOrderMark
       + '(= yaml =|---)'
       + '$([\\s\\S]*?)'
-      + '\\2'
+      + '(?:\\2|\\.\\.\\.)'
       + '$'
       + (process.platform === 'win32' ? '\\r?' : '')
       + '(?:\\n)?)'

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,23 @@ test('fm(string) - parse yaml delinetead by `= yaml =`', function(t) {
   })
 })
 
+test('fm(string) - parse yaml ended by `...`', function(t) {
+  read('dots-ending.md', function(err, data){
+    t.error(err, 'read(...) should not error')
+
+    var content = fm(data)
+    var meta = content.attributes
+    var body = content.body
+
+    t.equal(meta.title, 'Example with dots document ending')
+    t.equal(meta.description, 'Just an example of using `...`')
+    t.ok(body.match('It shouldn\'t break with ...'),
+      'should match body')
+
+    t.end()
+  })
+})
+
 test('fm(string) - string missing front-matter', function(t) {
   var content = fm('No front matter here')
 


### PR DESCRIPTION
Some authors use the [YAML document end marker](http://www.yaml.org/spec/1.2/spec.html#id2800401) to signify the end of the frontmatter section instead of "---". Notably `pandoc` [suggests this format](http://pandoc.org/README.html#extension-yaml_metadata_block). This patch implements support for such documents.