### PR TITLE
Add a TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+interface FrontMatterResult<T> {
+  readonly attributes: T
+  readonly body: string
+  readonly frontmatter: string
+}
+
+interface FM {
+  <T>(file: string): FrontMatterResult<T>
+  test(file: string): boolean
+}
+
+declare const fm: FM
+export = fm


### PR DESCRIPTION
This allows TypeScript users to just `npm install front-matter` and use it right away.