### PR TITLE
Failing test with nasty HRs

### DIFF
--- a/examples/no-front-matter-with-hrs.md
+++ b/examples/no-front-matter-with-hrs.md
@@ -1,0 +1,13 @@
+----
+
+Some markdown following a 4 dashes horizontal rule
+
+---
+
+# Heading 1 followed by 3 _underscores_
+
+___
+
+---
+
+Some more Markdown

--- a/test/index.js
+++ b/test/index.js
@@ -150,6 +150,19 @@ test('fm(string) - no front matter, markdown with hr', function (t) {
     })
 })
 
+test('fm(string) - not a front matter, markdown with nastier hrs', function (t) {
+  fs.readFile(
+    path.resolve(__dirname, '../examples/no-front-matter-with-hrs.md'),
+    'utf8',
+    function (err, data) {
+      t.error(err, 'read should not error')
+
+      var content = fm(data)
+      t.equal(content.body, data)
+      t.end()
+    })
+})
+
 test('fm(string) - complex yaml', function (t) {
   fs.readFile(
     path.resolve(__dirname, '../examples/complex-yaml.md'),


### PR DESCRIPTION
Hello, I'm opening this PR with a failing test, that yields the following result:

```js
{ 
 attributes: '___',
     body: '----\n\nSome markdown following a 4 dashes horizontal rule\n\n\nSome more Markdown\n',
     frontmatter: '# Heading 1 followed by 3 _underscores_\n\n___'
}
```

for the following string:

```
----

Some markdown following a 4 dashes horizontal rule

---

# Heading 1 followed by 3 _underscores_

___

---

Some more Markdown

```

Here is what seems to be wrong about it:

- I would expect `attributes` to always be a JSON, not a string.
- I did not know a frontmatter could be elsewhere than the start of a document. Is there a way for me to specify that I want to ignore frontmatters that are not at the start of a document?

I don't know if this is an issue with the regex of `front-matter` to detect where a frontmatter is in the text, or if it is an issue with `js-yaml` for returning something that is not a JSON. Any help is appreciated.