### PR TITLE
Add `bodyBegin` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ And end up with an object like this:
         title: 'Just hack\'n',
         description: 'Nothing to see here'
     },
-    body: '\nThis is some text about some stuff that happened sometime ago',
+    body: 'This is some text about some stuff that happened sometime ago',
+    bodyBegin: 6,
     frontmatter: 'title: Just hack\'n\ndescription: Nothing to see here'
 }
 ```
@@ -77,6 +78,7 @@ Return a `content` object with two properties:
 
 * `content.attributes` contains the extracted yaml attributes in json form
 * `content.body` contains the string contents below the yaml separators
+* `content.bodyBegin` contains the line number the body contents begins at
 * `content.frontmatter` contains the original yaml string contents
 
 # fm.test(string)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 interface FrontMatterResult<T> {
   readonly attributes: T
   readonly body: string
+  readonly bodyBegin: number;
   readonly frontmatter?: string
 }
 

--- a/index.js
+++ b/index.js
@@ -23,25 +23,51 @@ function extractor (string) {
   if (lines[0] && /= yaml =|---/.test(lines[0])) {
     return parse(string)
   } else {
-    return { attributes: {}, body: string }
+    return {
+      attributes: {},
+      body: string,
+      bodyBegin: 1
+    }
   }
+}
+
+function computeLocation (match, body) {
+  var line = 1
+  var pos = body.indexOf('\n')
+  var offset = match.index + match[0].length
+
+  while (pos !== -1) {
+    if (pos >= offset) {
+      return line
+    }
+    line++
+    pos = body.indexOf('\n', pos + 1)
+  }
+
+  return line
 }
 
 function parse (string) {
   var match = regex.exec(string)
-
   if (!match) {
     return {
       attributes: {},
-      body: string
+      body: string,
+      bodyBegin: 1
     }
   }
 
   var yaml = match[match.length - 1].replace(/^\s+|\s+$/g, '')
   var attributes = parser.load(yaml) || {}
   var body = string.replace(match[0], '')
+  var line = computeLocation(match, string)
 
-  return { attributes: attributes, body: body, frontmatter: yaml }
+  return {
+    attributes: attributes,
+    body: body,
+    bodyBegin: line,
+    frontmatter: yaml
+  }
 }
 
 function test (string) {

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,8 @@ test('fm(string) - parse yaml delinetead by `---`', function (t) {
       t.ok(content.body.match("Also this shouldn't be a problem"),
         'should match body')
 
+      t.equal(content.bodyBegin, 10)
+
       t.ok(content.frontmatter, 'should have a `frontmatter` key')
       t.ok(content.frontmatter.match('title: Three dashes marks the spot'), 'should match frontmatter')
       t.ok(content.frontmatter.match('expaned-description: with some --- crazy stuff in it'), 'should match frontmatter')
@@ -94,6 +96,7 @@ test('fm(string) - string missing body', function (t) {
       t.equal(content.attributes.title, 'Three dashes marks the spot')
       t.equal(content.attributes.tags.length, 3)
       t.equal(content.body, '')
+      t.equal(content.bodyBegin, 9)
       t.end()
     })
 })
@@ -146,6 +149,7 @@ test('fm(string) - no front matter, markdown with hr', function (t) {
 
       var content = fm(data)
       t.equal(content.body, data)
+      t.equal(content.bodyBegin, 1)
       t.end()
     })
 })
@@ -212,7 +216,8 @@ test('Supports live updating', function (t) {
 
   t.same(content, {
     attributes: {},
-    body: string
+    body: string,
+    bodyBegin: 1
   })
 
   string += '\n---\n'
@@ -220,6 +225,7 @@ test('Supports live updating', function (t) {
   t.same(content, {
     attributes: { foo: 'bar' },
     body: '',
+    bodyBegin: 4,
     frontmatter: 'foo: bar'
   })
 


### PR DESCRIPTION
Contains the line number the body contents begins at. Useful when the markdown
parser refers to errors at line/column.