### PR TITLE
Smaller published size

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "tape": "^4.4.0",
     "zuul": "^3.12.0"
   },
+  "files": [
+    "index.d.ts"
+  ],
   "contributors": [
     "Jason Campbell <jason@js.la> (http://twitter.com/jxson)",
     "Jordan Santell <jsantell@gmail.com> (https://github.com/jsantell)",


### PR DESCRIPTION
A small change to avoid publishing unnecessary files like tests/examples to NPM. Note that `index.js`, `LICENSE`, `README.md` and `package.json` get included automatically.

@jxson thanks a lot for maintaining this library! 

### Before

```bash
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE                     
npm notice 1.3kB Makefile                    
npm notice 1.6kB index.js                    
npm notice 6.2kB test/index.js               
npm notice 1.3kB package.json                
npm notice 53B   examples/bom.md             
npm notice 202B  examples/complex-yaml.md    
npm notice 191B  examples/dashes-seperator.md
npm notice 122B  examples/dots-ending.md     
npm notice 139B  examples/missing-body.md    
npm notice 124B  examples/no-front-matter.md 
npm notice 6.3kB README.md                   
npm notice 478B  examples/wrapped-text.md    
npm notice 154B  examples/yaml-seperator.md  
npm notice 282B  index.d.ts                  
npm notice 942B  .travis.yml                 
npm notice 318B  .zuul.yml                   
npm notice === Tarball Details === 
npm notice name:          front-matter                            
npm notice version:       3.2.0                                   
npm notice package size:  7.5 kB                                  
npm notice unpacked size: 20.8 kB                                 
npm notice total files:   17     
```

### After

```bash
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 1.6kB index.js    
npm notice 1.3kB package.json
npm notice 6.3kB README.md   
npm notice 282B  index.d.ts  
npm notice === Tarball Details === 
npm notice name:          front-matter                            
npm notice version:       3.2.0                                   
npm notice package size:  4.2 kB                                  
npm notice unpacked size: 10.6 kB                                 
npm notice total files:   5
```