### PR TITLE
testing in Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: node_js
 node_js:
 - stable
+- 12
 - 10
 - 9
 - 8


### PR DESCRIPTION
In TravisCI `stable` means Node 14. 
We ought to test in Node 12 too since it's so common. 