### PR TITLE
Fix case of `allowUnsafe` in boolean coercion

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function extractor (string, options) {
   string = string || ''
   var defaultOptions = { allowUnsafe: false }
   options = options instanceof Object ? {...defaultOptions, ...options} : defaultOptions
-  options.allowunsafe = Boolean(options.allowUnsafe)
+  options.allowUnsafe = Boolean(options.allowUnsafe)
   var lines = string.split(/(\r?\n)/)
   if (lines[0] && /= yaml =|---/.test(lines[0])) {
     return parse(string, options.allowUnsafe)


### PR DESCRIPTION
`options.allowunsafe` is not used anywhere so I think it is an error and it should be `options.allowUnsafe` instead.

Note that I made this PR with the GitHub web interface so I didn't test locally but because there is CI I think it's fine.