### PR TITLE
Fix incorrect type-declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,24 @@
-export interface FrontMatterResult<T> {
-  readonly attributes: T
-  readonly body: string
-  readonly bodyBegin: number;
-  readonly frontmatter?: string
+declare namespace fm {
+  export interface FrontMatterResult<T> {
+    readonly attributes: T
+    readonly body: string
+    readonly bodyBegin: number;
+    readonly frontmatter?: string
+  }
+  
+  export interface FrontMatterOptions {
+    /**
+     * Whether to use [safeload](https://github.com/nodeca/js-yaml#safeload-string---options-)
+     * @default true
+     */
+    allowUnsafe?: boolean
+  }
+
+  export interface FrontMatter {
+    <T>(file: string, options?: FrontMatterOptions): FrontMatterResult<T>
+    test(file: string): boolean
+  }
 }
 
-export interface FrontMatterOptions {
-  /**
-   * Whether to use [safeload](https://github.com/nodeca/js-yaml#safeload-string---options-)
-   * @default true
-   */
-  allowUnsafe?: boolean
-}
-
-interface FM {
-  <T>(file: string, options?: FrontMatterOptions): FrontMatterResult<T>
-  test(file: string): boolean
-}
-
-declare const fm: FM
-export default fm
+declare const fm: fm.FrontMatter;
+export = fm;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "Jean-Philippe Monette <contact@jpmonette.net> (https://github.com/jpmonette)",
     "Marc-André Arseneault <marc-andre@arsnl.ca> (https://github.com/arsnl)",
     "Bret Comnes <bcomnes@gmail.com> (http://bret.io)",
-    "Peter Bengtsson <mail@peterbe.com> (https://github.com/peterbe)"
+    "Peter Bengtsson <mail@peterbe.com> (https://github.com/peterbe)",
+    "Manuel Thalmann <m@nuth.ch> (https://nuth.ch)"
   ]
 }

--- a/test/index.errors.ts
+++ b/test/index.errors.ts
@@ -1,4 +1,4 @@
-import fm from '../'
+import fm = require('../')
 
 type Attributes = {
   title: string,

--- a/test/index.types.ts
+++ b/test/index.types.ts
@@ -1,4 +1,4 @@
-import fm from '../'
+import fm = require('../')
 
 type Attributes = {
   title: string,


### PR DESCRIPTION
## General
The `front-matter` module uses the `module.exports = fm`-pattern to expose the library.
Currently the type-declaration doesn't represent this correctly and instead asserts an `export default fm`.

This contradicts with each other and causes typescript to not work correctly.

This PR fixes the type-declarations accordingly.

## The Solution
The solution is to move every existing component (such as `FrontMatterOptions`, `FM` etc.) into a namespace which merges with the `fm`-function:
https://github.com/jxson/front-matter/blob/d3675655dc92a6aafa66960c02a8938d62e5809d/index.d.ts#L1-L23

Afterwards the `fm`-function can be exported the same way it is exported in the actual source-file (which is using an `export = fm`-expression):
https://github.com/jxson/front-matter/blob/d3675655dc92a6aafa66960c02a8938d62e5809d/index.d.ts#L24

Merging this PR fixes issue #76 